### PR TITLE
List open and closed orders should not be filtered unless explicitly specified by --pair parameter

### DIFF
--- a/clikraken/api/private/list_closed_orders.py
+++ b/clikraken/api/private/list_closed_orders.py
@@ -37,9 +37,9 @@ def list_closed_orders(args):
     ol = ol['buy'] + ol['sell']
 
     # filter out orders with zero volume executed
-    ol = [odict for odict in ol
-          if Decimal(odict['vol_exec']) > 0
-          and (odict['pair'] == asset_pair_short(args.pair) or args.pair == 'all')]
+    ol = [odict for odict in ol if Decimal(odict['vol_exec']) > 0]
+    if 'pair' in args and args.pair:
+        ol = [odict for odict in ol if odict['pair'] == args.pair or odict['pair'] == asset_pair_short(args.pair)]
 
     if not ol:
         return

--- a/clikraken/api/private/list_closed_orders.py
+++ b/clikraken/api/private/list_closed_orders.py
@@ -39,7 +39,7 @@ def list_closed_orders(args):
     # filter out orders with zero volume executed
     ol = [odict for odict in ol if Decimal(odict['vol_exec']) > 0]
     if 'pair' in args and args.pair:
-        ol = [odict for odict in ol if odict['pair'] == args.pair or odict['pair'] == asset_pair_short(args.pair)]
+        ol = [odict for odict in ol if odict['pair'] in [args.pair, asset_pair_short(args.pair)]]
 
     if not ol:
         return

--- a/clikraken/api/private/list_open_orders.py
+++ b/clikraken/api/private/list_open_orders.py
@@ -38,7 +38,7 @@ def list_open_orders(args):
         # filter orders based on currency pair
         if 'pair' in args and args.pair:
             ol[otype] = [odict for odict in ol[otype]
-                         if (odict['pair'] == asset_pair_short(args.pair) or args.pair == 'all')]
+                         if (odict['pair'] in [args.pair, asset_pair_short(args.pair)] or args.pair == 'all')]
         # sort orders by price
         ol[otype] = sorted(ol[otype], key=lambda odict: Decimal(odict['price']))
 

--- a/clikraken/api/private/list_open_orders.py
+++ b/clikraken/api/private/list_open_orders.py
@@ -36,8 +36,9 @@ def list_open_orders(args):
     # filter and sort orders by price in each category
     for otype in ol:
         # filter orders based on currency pair
-        ol[otype] = [odict for odict in ol[otype]
-                     if (odict['pair'] == asset_pair_short(args.pair) or args.pair == 'all')]
+        if 'pair' in args and args.pair:
+            ol[otype] = [odict for odict in ol[otype]
+                         if (odict['pair'] == asset_pair_short(args.pair) or args.pair == 'all')]
         # sort orders by price
         ol[otype] = sorted(ol[otype], key=lambda odict: Decimal(odict['price']))
 

--- a/clikraken/clikraken_cmd.py
+++ b/clikraken/clikraken_cmd.py
@@ -164,7 +164,7 @@ def parse_args():
         aliases=['ol'],
         help='[private] Get a list of your open orders',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser_olist.add_argument('-p', '--pair', default=gv.DEFAULT_PAIR, help=pair_help)
+    parser_olist.add_argument('-p', '--pair', default=None, help=pair_help)
     parser_olist.set_defaults(sub_func=list_open_orders)
 
     # List of closed orders
@@ -173,7 +173,7 @@ def parse_args():
         aliases=['cl'],
         help='[private] Get a list of your closed orders',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser_clist.add_argument('-p', '--pair', default=gv.DEFAULT_PAIR, help=pair_help)
+    parser_clist.add_argument('-p', '--pair', default=None, help=pair_help)
     parser_clist.set_defaults(sub_func=list_closed_orders)
 
     args = parser.parse_args()


### PR DESCRIPTION
Default commands like `clikraken ol` or `clikraken cl` should list full list of orders not filtered by default pair. Filtering can by applied by explicitly specifying pair: `clikraken ol -p XBTEUR`

Also, make possible to use short pair names for filtering like `ETHEUR` etc.