### PR TITLE
Print improvements and leverage example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ optional arguments:
 
 ### Usage examples
 
-Notice: Without the `-p` option, the default currency pair is taken from the settings file or the aforementionned environment variable, defaulting to `XETHZEUR` if neither of those exists.
+Notice: Without the `-p` option, the default currency pair is taken from the settings file or the aforementioned environment variable, defaulting to `XETHZEUR` if neither of those exists.
 
 ```
 clikraken ticker

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ clikraken place sell 0.5 13.3701
 clikraken cancel OUQUPX-9FBMJ-DL7L6W
 ```
 
+Using leverage (maximum multiplier allowed depends on the currency pair chosen):
+
+```
+# open a short position with 5:1 leverage
+clikraken place sell 0.1 -l 5
+
+clikraken positions
+clikraken trade_balance
+
+# to close an open position the same volume and leverage should be used
+clikraken place buy -t limit 0.1 1492.0 -l 5
+```
+
 Examples in another currency pair:
 
 ```

--- a/src/clikraken/api/private/get_trade_balance.py
+++ b/src/clikraken/api/private/get_trade_balance.py
@@ -21,20 +21,15 @@ def get_trade_balance(args=None):
 
     res = query_api('private', 'TradeBalance', api_params, args)
 
-    tb_fields = {
-        'eb': 'equivalent balance',
-        'tb': 'trade balance',
-        'm': 'margin amount of open positions',
-        'n': 'unrealized net profit/loss of open positions',
-        'c': 'cost basis of open positions',
-        'v': 'current floating valuation of open positions',
-        'e': 'equity',
-        'mf': 'free margin',
-        'ml': 'margin level',
-    }
-
-    tbal_list = []
-    for k in res:
-        if k in tb_fields:
-            tbal_list.append([tb_fields[k], res[k]])
+    tbal_list = [
+        ['equivalent balance', res['eb']],
+        ['trade balance', res['tb']],
+        ['margin amount of open positions', res['m']],
+        ['cost basis of open positions', res['c']],
+        ['current floating valuation of open positions', res['v']],
+        ['equity', res['e']],
+        ['free margin', res['mf']],
+        ['margin level', res['ml']],
+        ['unrealized net profit/loss of open positions', res['n']],
+    ]
     print(tabulate(tbal_list))

--- a/src/clikraken/api/private/list_open_positions.py
+++ b/src/clikraken/api/private/list_open_positions.py
@@ -10,6 +10,7 @@ Licensed under the Apache License, Version 2.0. See the LICENSE file.
 """
 
 from datetime import datetime
+from collections import OrderedDict
 
 from clikraken.api.api_utils import query_api
 from clikraken.clikraken_utils import _tabulate as tabulate
@@ -25,9 +26,23 @@ def list_open_positions(args):
 
     res = query_api('private', 'OpenPositions', api_params, args)
 
+    pos_list = []
     for order in res.values():
-        # decode timestamp from unix time
-        order['time'] = datetime.fromtimestamp(order['time'])
+        pos = OrderedDict()
+        pos['ordertxid'] = order['ordertxid']
+        pos['opening time'] = datetime.fromtimestamp(order['time'])
+        pos['type'] = order['type']
+        pos['volume'] = order['vol']
+        pos['pair'] = order['pair']
+        pos['ordertype'] = order['ordertype']
+        pos['cost'] = order['cost']
+        pos['fee'] = order['fee']
+        pos['margin'] = order['margin']
+        pos['value'] = order['value']
+        pos['profit/loss'] = order['net']
+        pos['rollover time'] = datetime.fromtimestamp(int(order['rollovertm']))
+        pos['rollover terms'] = order['terms']
 
-    # TODO pretty print
-    print(tabulate(res.values(), headers="keys"))
+        pos_list.append(pos)
+
+    print(tabulate(pos_list, headers="keys"))


### PR DESCRIPTION
I reworked a bit the output printing for 'tbal' and 'pos' commands, hiding useless fields and
printing the entries in a deterministic way through lists and OrderedDicts;
also I've added an example of leverage usage in the README.