### PR TITLE
Add -r/--userref param to place command

### DIFF
--- a/src/clikraken/api/private/place_order.py
+++ b/src/clikraken/api/private/place_order.py
@@ -44,6 +44,9 @@ def place_order(args):
             logger.warn('price is ignored for market orders!')
         check_trading_agreement()
 
+    if args.userref:
+        api_params['userref'] = args.userref
+
     oflags = []  # order flags
     if args.ordertype == 'limit':
         # for limit orders, always set post only order flag

--- a/src/clikraken/clikraken_cmd.py
+++ b/src/clikraken/clikraken_cmd.py
@@ -192,6 +192,7 @@ def parse_args():
                               help="order type. Currently implemented: [limit, market].")
     parser_place.add_argument('-s', '--starttm', default=0, help="scheduled start time")
     parser_place.add_argument('-e', '--expiretm', default=0, help="expiration time")
+    parser_place.add_argument('-r', '--userref', help="user reference id.  32-bit signed number.  (optional)")
     parser_place.add_argument('-q', '--viqc', action='store_true', help="volume in quote currency")
     parser_place.add_argument('-v', '--validate', action='store_true', help="validate inputs only. do not submit order")
     parser_place.set_defaults(sub_func=place_order)


### PR DESCRIPTION
Kraken API has the param `userref` [(source)](https://www.kraken.com/help/api#add-standard-order) that allows to add an user reference to the order.