### PR TITLE
Add auto volume calculation based on balance and price when placing orders

### DIFF
--- a/src/clikraken/api/private/get_balance.py
+++ b/src/clikraken/api/private/get_balance.py
@@ -26,7 +26,7 @@ def get_balance(args=None):
 
     bal_list = []
     for asset in res:
-        # Initialize an OrderedDict to garantee the column order
+        # Initialize an OrderedDict to guarantee the column order
         # for later use with the tabulate function
         asset_dict = OrderedDict()
         # Remove leading Z or X from asset pair if it is of length 4

--- a/src/clikraken/api/private/place_order.py
+++ b/src/clikraken/api/private/place_order.py
@@ -8,6 +8,7 @@ and outputs the results in a tabular format.
 
 Licensed under the Apache License, Version 2.0. See the LICENSE file.
 """
+from decimal import Decimal, ROUND_DOWN
 
 import clikraken.global_vars as gv
 
@@ -60,7 +61,7 @@ def place_order(args):
         else:
             api_params['price'] = args.price
             if args.volume == 'auto':
-                api_params['volume'] = "%.4f" % get_auto_volume(args)
+                api_params['volume'] = get_auto_volume(args)
     elif args.ordertype == 'market':
         if args.price is not None:
             logger.warn('price is ignored for market orders!')

--- a/src/clikraken/api/private/place_order.py
+++ b/src/clikraken/api/private/place_order.py
@@ -8,7 +8,6 @@ and outputs the results in a tabular format.
 
 Licensed under the Apache License, Version 2.0. See the LICENSE file.
 """
-from decimal import Decimal, ROUND_DOWN
 
 import clikraken.global_vars as gv
 

--- a/src/clikraken/clikraken_cmd.py
+++ b/src/clikraken/clikraken_cmd.py
@@ -13,7 +13,6 @@ Licensed under the Apache License, Version 2.0. See the LICENSE file.
 import argparse
 import codecs
 import textwrap
-from decimal import Decimal
 import sys
 
 import clikraken.global_vars as gv

--- a/src/clikraken/clikraken_cmd.py
+++ b/src/clikraken/clikraken_cmd.py
@@ -184,7 +184,7 @@ def parse_args():
         help='[private] Place an order',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser_place.add_argument('type', choices=['sell', 'buy'])
-    parser_place.add_argument('volume', type=Decimal)
+    parser_place.add_argument('volume', help='\'auto\' to query and use relevant balance')
     parser_place.add_argument('price', default=None, nargs='?')
     parser_place.add_argument('-l', '--leverage', default="none", help='leverage for margin trading')
     parser_place.add_argument('-p', '--pair', default=gv.DEFAULT_PAIR, help=pair_help)


### PR DESCRIPTION
I really wanted this feature so I felt the need to code it in!
Create a buy order with:
clikraken place buy auto <price>
New feature will query current balance of the second of the currency pair (eg: EUR for BCHEUR) and will calculate the max volume for the given price.
Similar for sell orders but slightly less useful.